### PR TITLE
Local scope the msg before putting it on the channel, so it never points to a different message

### DIFF
--- a/client.go
+++ b/client.go
@@ -278,6 +278,7 @@ func (c *Client) send(req *request) (*metaMessage, error) {
 	// 3. Handle messages to just-created subscriptions
 
 	for _, msg := range messages {
+		msg := msg
 		if req.Channel == msg.Channel {
 			reply = &msg
 		} else {


### PR DESCRIPTION

essentially fixes #1 at least in my tests